### PR TITLE
Set CascadeDelete for everything but CardFile, manual deletion needed…

### DIFF
--- a/Indextrious/Data/ApplicationDbContext.cs
+++ b/Indextrious/Data/ApplicationDbContext.cs
@@ -23,7 +23,7 @@ namespace Indextrious.Data
                 .HasMany(cf => cf.SubFiles)
                 .WithOne(cf => cf.ParentCardFile)
                 .HasForeignKey(cf => cf.ParentCardFileId)
-                .OnDelete(DeleteBehavior.Restrict); // Adjust the delete behavior as needed
+                .OnDelete(DeleteBehavior.Restrict); // Deletion of CardFiles will have to be dealt with manually
 
             // Relationship between CardFile and CardCollection
             modelBuilder.Entity<CardFile>()
@@ -31,14 +31,15 @@ namespace Indextrious.Data
                 .WithMany(cc => cc.CardFiles)
                 .HasForeignKey(cf => cf.ParentCollectionId)
                 .IsRequired()
-                .OnDelete(DeleteBehavior.Restrict);
+                .OnDelete(DeleteBehavior.Cascade);
 
             // Relationship between ApplicationUser and CardCollection
             modelBuilder.Entity<ApplicationUser>()
                 .HasMany(u => u.UserCollections)
                 .WithOne(cc => cc.Owner)
                 .HasForeignKey(cc => cc.OwnerId)
-                .IsRequired();
+                .IsRequired()
+                .OnDelete(DeleteBehavior.Cascade); ;
         }
     }
 }

--- a/Indextrious/Migrations/20230713172950_Initial.Designer.cs
+++ b/Indextrious/Migrations/20230713172950_Initial.Designer.cs
@@ -12,7 +12,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Indextrious.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20230712202621_Initial")]
+    [Migration("20230713172950_Initial")]
     partial class Initial
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -318,7 +318,7 @@ namespace Indextrious.Migrations
                     b.HasOne("Indextrious.Models.CardCollection", "ParentCollection")
                         .WithMany("CardFiles")
                         .HasForeignKey("ParentCollectionId")
-                        .OnDelete(DeleteBehavior.Restrict)
+                        .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
                     b.Navigation("ParentCardFile");

--- a/Indextrious/Migrations/20230713172950_Initial.cs
+++ b/Indextrious/Migrations/20230713172950_Initial.cs
@@ -191,7 +191,7 @@ namespace Indextrious.Migrations
                         column: x => x.ParentCollectionId,
                         principalTable: "CardCollections",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.Restrict);
+                        onDelete: ReferentialAction.Cascade);
                     table.ForeignKey(
                         name: "FK_CardFiles_CardFiles_ParentCardFileId",
                         column: x => x.ParentCardFileId,

--- a/Indextrious/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Indextrious/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -316,7 +316,7 @@ namespace Indextrious.Migrations
                     b.HasOne("Indextrious.Models.CardCollection", "ParentCollection")
                         .WithMany("CardFiles")
                         .HasForeignKey("ParentCollectionId")
-                        .OnDelete(DeleteBehavior.Restrict)
+                        .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
                     b.Navigation("ParentCardFile");


### PR DESCRIPTION
…, re-added migrations

closes #28 

CardFile is self-referencing so it will need manual deletion. Everything else is cascade delete behavior.